### PR TITLE
Rework tone of about section to be more professional

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,23 +313,46 @@
                             Chirality
                         </h2>
                         <h4>
-                            The Ragav Project
+                            About
                         </h4>
                         <p>
-                            Chirality started out as the 'Ragav' project, after trauma from a previous band that
-                            co-founded,
-                            and having seen integrity and ethical issues in that band.
-                            The Ragav project evolved into a unique identity and in-time became Chirality of today.
-
-                            As an immigrant to the US and having grown up among many different cultures, Ragav's musical
-                            tastes are as much a melting pot as my adopted country.
-                            The 'Ragav' project was, and Chirality remains today an east meets west fusion, that is a
-                            musical expression of this very
-                            melting pot of cultures.
-                            It fuses together genres as far away as South-Indian Carnatic, and progressive Metal.
-                            The song writing is emblematic of this same blend of cultures - from homefree, which is a
-                            positive spin on the immigrant experience in the US, to dual states of existence, which is a
-                            song that carries stereotypically Seattle-grunge themes of being lost among a chaotic world.
+                            Chirality was born from a deep and untapped well of creative ideation discovered by founder
+                            and lead guitarist, Ragav Venkatesan. Initially taking the shape of <i>The Ragav
+                                Project</i>—an outlet for his introspective musings—Ragav&#39;s unique prespectives
+                            as an immigrant thriving in a new cultural landscape led to the foundation of a new
+                            experimental
+                            journey with a rarely encountered blend of musical textures. Soon after, the band was joined
+                            by Eshaan
+                            Thakar (drums) and Aravind Nidadavolu (bass) and the combined musical exploration of the
+                            three members led to band&#39;s rebirth as Chirality.
+                        </p>
+                        <p>
+                            The name <i>Chirality</i> is a scientific term referring to the “handedness” or asymmetrical
+                            properties of an object&#39;s mirror image. The band embodies this concept through its
+                            east-meets-west
+                            fusion of musical philosophies. This unconventional blend creates a powerful gravitational
+                            pull,
+                            drawing in a diverse audience from various musical backgrounds—ranging from an untapped
+                            community
+                            of immigrant metalheads raised on
+                            <a target="_blank"
+                                href="https://open.spotify.com/artist/2dJEdZ3JefqNjAz9KH3qnK">Motherjane</a>
+                            and <a target="_blank"
+                                href="https://open.spotify.com/artist/29z5chNteRELh8vVAnKind">Avial</a>
+                            to a rising wave of local Seattle listeners shaped by
+                            <a target="_blank"
+                                href="https://open.spotify.com/artist/64tNsm6TnZe2zpcMVMOoHL?autoplay=true">
+                                Alice in Chains</a>
+                            and
+                            <a target="_blank"
+                                href="https://open.spotify.com/artist/5NXHXK6hOCotCF8lvGM1I0?autoplay=true">
+                                Porcupine Tree</a>. Chirality&#39;s fans share an insatiable hunger for its rapturous
+                            melodies,
+                            unconventional rhythmic structures, and fearless exploration of the vast unknown—viewed
+                            through
+                            the lens of a mirror.
+                        </p>
+                        <p>
                         <table>
                             <tr>
                                 <td>Genre</td>
@@ -353,21 +376,6 @@
                                 </td>
                             </tr>
                         </table>
-                        </p>
-                        <p>
-                            Consequently, Chirality draws a diverse audience from a variety of different musical
-                            afflictions.
-                            There is a large closeted metalhead audience-base among the immigrant tech-community of
-                            Seattle that is eager for new original music,
-                            having followed bands such as
-                            <a target="_blank"
-                                href="https://open.spotify.com/artist/2dJEdZ3JefqNjAz9KH3qnK">Motherjane</a>
-                            and
-                            <a target="_blank" href="https://open.spotify.com/artist/29z5chNteRELh8vVAnKind">Avial</a>
-                            .
-                            There is also a new wave of local Seattle audiences from fans of bands such as Alice in
-                            Chains to those such as Porcupine Tree, that
-                            are also very receptive to this style of east-meets-west fusion-metal music.
                         </p>
                         <p>
                         <table>
@@ -1220,7 +1228,8 @@
                         <h2 class="uk-h3">Chop Suey - 5/1/25</h2>
                         <p>
                             Tickets and more details on the show can be found
-                            <u><a href="https://www.ticketweb.com/event/mantra-chirality-rc-cars-on-chop-suey-tickets/14300393?REFID=ARTIST">here</a></u>
+                            <u><a
+                                    href="https://www.ticketweb.com/event/mantra-chirality-rc-cars-on-chop-suey-tickets/14300393?REFID=ARTIST">here</a></u>
                         </p>
                         <p>
                             Bands on Bill: RC Cars on Mars, Mantra.


### PR DESCRIPTION
The initial version of the about section referred to a previous band and did not have tonal cohesion. This has been rectified by rewriting the about paragraph to focus on the band's origins as a creative outlet as opposed to the previous negative emotional context